### PR TITLE
Remove python 3.12 f-string feature

### DIFF
--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -2,9 +2,6 @@ name: Check-Python
 
 on:
   pull_request:
-    branches:
-      - main
-      - development
     paths:
       - backend/**
 

--- a/backend/compact-connect/common_constructs/alarm_topic.py
+++ b/backend/compact-connect/common_constructs/alarm_topic.py
@@ -34,7 +34,7 @@ class AlarmTopic(Topic):
         self.slack_channel_integrations = {}
         for config in slack_subscriptions:
             self.slack_channel_integrations[config['channel_name']] = SlackChannelConfiguration(
-                self, f'{config['channel_name']}-SlackChannelConfiguration',
+                self, f'{config["channel_name"]}-SlackChannelConfiguration',
                 notification_topics=[self],
                 workspace_id=config['workspace_id'],
                 channel_id=config['channel_id']

--- a/backend/compact-connect/pipeline/backend_pipeline.py
+++ b/backend/compact-connect/pipeline/backend_pipeline.py
@@ -68,6 +68,7 @@ class BackendPipeline(CdkCodePipeline):
                 primary_output_directory=os.path.join(cdk_path, 'cdk.out'),
                 commands=[
                     f'cd {cdk_path}',
+                    'python --version',
                     'npm install -g aws-cdk',
                     'python -m pip install -r requirements.txt',
                     'cdk synth'


### PR DESCRIPTION
### Description List
- Turns out, the latest CodeBuild platform is not using the latest python version (3.12). This update removes use of a python 3.12 f-string feature that is causing synthesis to fail in the pipeline.