### PR TITLE
Adding support to send cognito user email notifications using custom domain

### DIFF
--- a/backend/compact-connect/README.md
+++ b/backend/compact-connect/README.md
@@ -103,7 +103,7 @@ its environment:
    not be able to log in to the UI hosted in CloudFront. The Oauth2 authentication process requires a predictable
    callback url to be pre-configured, which the domain name provides. You can still run a local UI against this app,
    so long as you leave the `allow_local_ui` context value set to `true` in your environment's context.
-2) *Optional if testing SES email notifications:* By default, AWS does not allow sending emails to unverified email 
+2) *Optional if testing SES email notifications with custom domain:* By default, AWS does not allow sending emails to unverified email 
    addresses. See [SES Sandbox](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html). If you need
    to test SES email notifications and do not want to request AWS to remove your account from the SES sandbox, you will 
    need to set up a verified SES email identity for each address you want to send emails to. 

--- a/backend/compact-connect/README.md
+++ b/backend/compact-connect/README.md
@@ -103,14 +103,19 @@ its environment:
    not be able to log in to the UI hosted in CloudFront. The Oauth2 authentication process requires a predictable
    callback url to be pre-configured, which the domain name provides. You can still run a local UI against this app,
    so long as you leave the `allow_local_ui` context value set to `true` in your environment's context.
-2) Copy [cdk.context.sandbox-example.json](./cdk.context.sandbox-example.json) to `cdk.context.json`.
-3) At the top level of the JSON structure update the `"environment_name"` field to your own name.
-4) Update the environment entry under `ssm_context.environments` to your own name and your own AWS sandbox account id,
+2) *Optional if testing SES email notifications:* By default, AWS does not allow sending emails to unverified email 
+   addresses. See [SES Sandbox](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html). If you need
+   to test SES email notifications and do not want to request AWS to remove your account from the SES sandbox, you will 
+   need to set up a verified SES email identity for each address you want to send emails to. 
+   See [Creating an email address identity](https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#verify-email-addresses-procedure)
+3) Copy [cdk.context.sandbox-example.json](./cdk.context.sandbox-example.json) to `cdk.context.json`.
+4) At the top level of the JSON structure update the `"environment_name"` field to your own name.
+5) Update the environment entry under `ssm_context.environments` to your own name and your own AWS sandbox account id,
    and domain name, if you set one up. If you opted not to create a HostedZone, just remove the `domain_name` field.
    The key under `environments` must match the value you put under `environment_name`.
-5) Configure your aws cli to authenticate against your own account.
-6) Run `cdk bootstrap` to add some base CDK support infrastructure to your AWS account.
-7) Run `cdk deploy 'Sandbox/*'` to get the initial stack resources deployed.
+6) Configure your aws cli to authenticate against your own account.
+7) Run `cdk bootstrap` to add some base CDK support infrastructure to your AWS account.
+8) Run `cdk deploy 'Sandbox/*'` to get the initial stack resources deployed.
 
 ### Subsequent sandbox deploys:
 For any future deploys, everything is set up so a simple `cdk deploy 'Sandbox/*'` should update all your infrastructure
@@ -131,6 +136,8 @@ that is done, perform the following steps to deploy the CI/CD pipeline into the 
   the next step.
 - Create a new Route53 hosted zone for the domain name you plan to use for the app in each of the production AWS
   account and the test AWS account. See [About Route53 hosted zones](#about-route53-hosted-zones) below for more detail.
+- Request AWS to remove your account from the SES sandbox and wait for them to complete this request.
+  See [SES Sandbox](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html).
 - Copy the `cdk.context.production-example.json` file to `cdk.context.json` and update accounts and other identifiers,
   including the Code Star connection you just had created to match the identifiers for your actual accounts and
   resources.

--- a/backend/compact-connect/cdk.context.production-example.json
+++ b/backend/compact-connect/cdk.context.production-example.json
@@ -8,7 +8,6 @@
         "region": "us-east-1",
         "connection_arn": "arn:aws:codestar-connections:us-east-1:000000000000:connection/11111111-1111-1111-111111111111",
         "notifications": {
-          "ses_feedback_forwarding_email": "justin@example.com",
           "email": [
             "justin@example.com"
           ],
@@ -26,7 +25,7 @@
         "region": "us-east-1",
         "domain_name": "compactconnect.org",
         "notifications": {
-          "ses_feedback_forwarding_email": "justin@example.com",
+          "ses_operations_support_email": "justin@example.com",
           "email": [
             "justin@example.com"
           ],
@@ -45,7 +44,7 @@
         "domain_name": "test.compactconnect.org",
         "allow_local_ui": true,
         "notifications": {
-          "ses_feedback_forwarding_email": "justin@example.com",
+          "ses_operations_support_email": "justin@example.com",
           "email": [
             "justin@example.com"
           ],

--- a/backend/compact-connect/cdk.context.production-example.json
+++ b/backend/compact-connect/cdk.context.production-example.json
@@ -8,6 +8,7 @@
         "region": "us-east-1",
         "connection_arn": "arn:aws:codestar-connections:us-east-1:000000000000:connection/11111111-1111-1111-111111111111",
         "notifications": {
+          "ses_feedback_forwarding_email": "justin@example.com",
           "email": [
             "justin@example.com"
           ],
@@ -25,6 +26,7 @@
         "region": "us-east-1",
         "domain_name": "compactconnect.org",
         "notifications": {
+          "ses_feedback_forwarding_email": "justin@example.com",
           "email": [
             "justin@example.com"
           ],
@@ -43,6 +45,7 @@
         "domain_name": "test.compactconnect.org",
         "allow_local_ui": true,
         "notifications": {
+          "ses_feedback_forwarding_email": "justin@example.com",
           "email": [
             "justin@example.com"
           ],

--- a/backend/compact-connect/cdk.context.sandbox-example.json
+++ b/backend/compact-connect/cdk.context.sandbox-example.json
@@ -11,6 +11,7 @@
         "domain_name": "justin.compactconnect.org",
         "allow_local_ui": true,
         "notifications": {
+          "ses_feedback_forwarding_email": "justin@example.com",
           "email": [
             "justin@example.com"
           ]

--- a/backend/compact-connect/cdk.context.sandbox-example.json
+++ b/backend/compact-connect/cdk.context.sandbox-example.json
@@ -11,7 +11,7 @@
         "domain_name": "justin.compactconnect.org",
         "allow_local_ui": true,
         "notifications": {
-          "ses_feedback_forwarding_email": "justin@example.com",
+          "ses_operations_support_email": "justin@example.com",
           "email": [
             "justin@example.com"
           ]

--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -16,6 +16,7 @@ class UserPool(CdkUserPool):
             cognito_domain_prefix: str,
             environment_name: str,
             encryption_key: IKey,
+            email: UserPoolEmail,
             removal_policy,
             **kwargs
     ):
@@ -23,7 +24,7 @@ class UserPool(CdkUserPool):
             scope, construct_id,
             removal_policy=removal_policy,
             deletion_protection=removal_policy != RemovalPolicy.DESTROY,
-            email=UserPoolEmail.with_cognito(),
+            email=email,
             # user_invitation=UserInvitationConfig(...),
             account_recovery=AccountRecovery.EMAIL_ONLY,
             auto_verify=AutoVerifiedAttrs(email=True),

--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -14,7 +14,8 @@ from stacks.persistent_stack.provider_table import ProviderTable
 from stacks.persistent_stack.staff_users import StaffUsers
 from stacks.persistent_stack.user_email_notifications import UserEmailNotifications
 
-
+# cdk leverages instance attributes to make resource exports accessible to other stacks
+# pylint: disable=too-many-instance-attributes
 class PersistentStack(AppStack):
     """
     The stack that holds long-lived resources such as license data and other things that should probably never

--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -1,5 +1,6 @@
 from aws_cdk import RemovalPolicy
 from aws_cdk.aws_kms import Key
+from aws_cdk.aws_cognito import UserPoolEmail
 from constructs import Construct
 
 from common_constructs.access_logs_bucket import AccessLogsBucket
@@ -11,6 +12,7 @@ from stacks.persistent_stack.license_table import LicenseTable
 from stacks.persistent_stack.event_bus import EventBus
 from stacks.persistent_stack.provider_table import ProviderTable
 from stacks.persistent_stack.staff_users import StaffUsers
+from stacks.persistent_stack.user_email_notifications import UserEmailNotifications
 
 
 class PersistentStack(AppStack):
@@ -60,6 +62,13 @@ class PersistentStack(AppStack):
         # The new data resources
         self._add_data_resources(removal_policy=removal_policy)
 
+        self.user_email_notifications = UserEmailNotifications(
+            self, 'UserEmailNotifications',
+            environment_context=environment_context,
+            hosted_zone=self.hosted_zone,
+            master_key=self.shared_encryption_key,
+        )
+
         staff_prefix = f'{app_name}-staff'
         self.staff_users = StaffUsers(
             self, 'StaffUsers',
@@ -68,8 +77,17 @@ class PersistentStack(AppStack):
             environment_name=environment_name,
             environment_context=environment_context,
             encryption_key=self.shared_encryption_key,
+            user_pool_email=UserPoolEmail.with_ses(
+                from_email=f"no-reply@{self.hosted_zone.zone_name}",
+                ses_verified_domain=self.hosted_zone.zone_name,
+                configuration_set_name=self.user_email_notifications.config_set.configuration_set_name
+            ),
             removal_policy=removal_policy
         )
+        # The SES email identity needs to be created before the user pool
+        # so that the domain address will be verified before being referenced
+        # by the user pool email settings
+        self.staff_users.node.add_dependency(self.user_email_notifications)
 
     def _add_mock_data_resources(self):
         self.mock_bulk_uploads_bucket = BulkUploadsBucket(

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import json
 import os
 
-from aws_cdk.aws_cognito import ResourceServerScope, UserPoolOperation, LambdaVersion
+from aws_cdk.aws_cognito import ResourceServerScope, UserPoolOperation, LambdaVersion, UserPoolEmail
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions
 from constructs import Construct
@@ -23,6 +23,7 @@ class StaffUsers(UserPool):
             environment_name: str,
             environment_context: dict,
             encryption_key: IKey,
+            user_pool_email: UserPoolEmail,
             removal_policy,
             **kwargs
     ):
@@ -32,6 +33,7 @@ class StaffUsers(UserPool):
             environment_name=environment_name,
             encryption_key=encryption_key,
             removal_policy=removal_policy,
+            email=user_pool_email,
             **kwargs
         )
         stack: ps.PersistentStack = ps.PersistentStack.of(self)

--- a/backend/compact-connect/stacks/persistent_stack/user_email_notifications.py
+++ b/backend/compact-connect/stacks/persistent_stack/user_email_notifications.py
@@ -24,8 +24,7 @@ class UserEmailNotifications(Construct):
         super().__init__(scope, construct_id, **kwargs)
 
         domain_name = hosted_zone.zone_name
-        # TODO - this should be a new context variable
-        operation_email = environment_context['notifications']['email'][0]
+        operation_email = environment_context['notifications']['ses_feedback_forwarding_email']
 
 
         self.email_feedback_topic = Topic(self, "FeedbackTopic",

--- a/backend/compact-connect/stacks/persistent_stack/user_email_notifications.py
+++ b/backend/compact-connect/stacks/persistent_stack/user_email_notifications.py
@@ -24,7 +24,7 @@ class UserEmailNotifications(Construct):
         super().__init__(scope, construct_id, **kwargs)
 
         domain_name = hosted_zone.zone_name
-        operation_email = environment_context['notifications']['ses_feedback_forwarding_email']
+        operation_email = environment_context['notifications']['ses_operations_support_email']
 
 
         self.email_feedback_topic = Topic(self, "FeedbackTopic",
@@ -41,7 +41,6 @@ class UserEmailNotifications(Construct):
 
         self.config_set.add_event_destination(id="EmailFeedbackEventDestination",
                                          destination=EventDestination.sns_topic(self.email_feedback_topic),
-                                         configuration_set_event_destination_name="EmailFeedbackDestination",
                                          enabled=True,
                                          events=[EmailSendingEvent.BOUNCE,
                                                  EmailSendingEvent.COMPLAINT]

--- a/backend/compact-connect/stacks/persistent_stack/user_email_notifications.py
+++ b/backend/compact-connect/stacks/persistent_stack/user_email_notifications.py
@@ -72,5 +72,3 @@ class UserEmailNotifications(Construct):
                   record_name=f"_dmarc.{domain_name}",
                   values=[f"v=DMARC1;p=reject;rua=mailto:{operation_email}"]
                   )
-
-

--- a/backend/compact-connect/stacks/persistent_stack/user_email_notifications.py
+++ b/backend/compact-connect/stacks/persistent_stack/user_email_notifications.py
@@ -1,0 +1,77 @@
+from aws_cdk.aws_iam import ServicePrincipal
+from aws_cdk.aws_ses import EmailIdentity, Identity, ConfigurationSet, EmailSendingEvent, EventDestination
+from aws_cdk.aws_sns import Topic, Subscription, SubscriptionProtocol
+from aws_cdk.aws_route53 import TxtRecord, IHostedZone
+from aws_cdk.aws_kms import IKey
+
+from constructs import Construct
+
+
+class UserEmailNotifications(Construct):
+    """
+    This Construct leverages SES to set up an email notification system to send cognito user events from our custom
+    domain with necessary SPF, DKIM, and DMARC verification records.
+
+    The topic is set up to forward all bounce and complaint events to the provided email address.
+    """
+    def __init__(
+            self, scope: Construct, construct_id: str, *,
+            hosted_zone: IHostedZone,
+            environment_context: dict,
+            master_key: IKey,
+            **kwargs
+    ):
+        super().__init__(scope, construct_id, **kwargs)
+
+        domain_name = hosted_zone.zone_name
+        # TODO - this should be a new context variable
+        operation_email = environment_context['notifications']['email'][0]
+
+
+        self.email_feedback_topic = Topic(self, "FeedbackTopic",
+                                          display_name="Email Feedback Forwarding Topic",
+                                          master_key=master_key,
+                                          enforce_ssl=True,
+                                          )
+        Subscription(self, "FeedbackSubscription",
+                     topic=self.email_feedback_topic,
+                     protocol=SubscriptionProtocol.EMAIL,
+                     endpoint=operation_email)
+
+        self.config_set = ConfigurationSet(self, "ConfigSet")
+
+        self.config_set.add_event_destination(id="EmailFeedbackEventDestination",
+                                         destination=EventDestination.sns_topic(self.email_feedback_topic),
+                                         configuration_set_event_destination_name="EmailFeedbackDestination",
+                                         enabled=True,
+                                         events=[EmailSendingEvent.BOUNCE,
+                                                 EmailSendingEvent.COMPLAINT]
+                                         )
+
+        ses_principal = ServicePrincipal("ses.amazonaws.com")
+        self.email_feedback_topic.grant_publish(ses_principal)
+        # grant SES the ability to encrypt bounce and complaint notifications using the KMS key
+        master_key.grant_encrypt_decrypt(ses_principal)
+
+
+        # Create SES Email Identity with DKIM enabled
+        self.email_identity = EmailIdentity(self, "EmailIdentity",
+            # by using the hosted zone resource, cdk will automatically
+            # create all the necessary DNS records for DKIM and SPF authentication
+            identity=Identity.public_hosted_zone(hosted_zone),
+            mail_from_domain=f"no-reply.{domain_name}",
+            configuration_set=self.config_set
+        )
+        # grant cognito the ability to send email from this identity
+        self.email_identity.grant_send_email(ServicePrincipal("cognito-idp.amazonaws.com"))
+
+        # Add DMARC record to Route 53 with policy set to 'reject'
+        # this will cause email servers to reject emails that do not pass SPF and DKIM checks
+        # see https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dmarc.html
+        TxtRecord(self, "DMARCRecord",
+                  zone=hosted_zone,
+                  record_name=f"_dmarc.{domain_name}",
+                  values=[f"v=DMARC1;p=reject;rua=mailto:{operation_email}"]
+                  )
+
+


### PR DESCRIPTION
### Requirements List
- 

### Description List
- In order for the cognito user pool to send emails
from the custom domain, we need to set up an SES
identity along with necessary DNS records to verify
that the domain may be used to send emails.
- This also sets up an SNS topic which will forward
all bounce or complaint notifications to an
operations team email address.

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review

Closes #149
