### PR TITLE
Setup initial construct for provider user pool

### DIFF
--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -12,6 +12,7 @@ from stacks.persistent_stack.license_table import LicenseTable
 from stacks.persistent_stack.event_bus import EventBus
 from stacks.persistent_stack.provider_table import ProviderTable
 from stacks.persistent_stack.staff_users import StaffUsers
+from stacks.persistent_stack.provider_users import ProviderUsers
 from stacks.persistent_stack.user_email_notifications import UserEmailNotifications
 
 # cdk leverages instance attributes to make resource exports accessible to other stacks
@@ -90,11 +91,25 @@ class PersistentStack(AppStack):
             user_pool_email=user_pool_email_settings,
             removal_policy=removal_policy
         )
+
+        provider_prefix = f'{app_name}-provider'
+        self.provider_users = ProviderUsers(
+            self, 'ProviderUsers',
+            cognito_domain_prefix=provider_prefix if environment_name == 'prod'
+            else f'{provider_prefix}-{environment_name}',
+            environment_name=environment_name,
+            environment_context=environment_context,
+            encryption_key=self.shared_encryption_key,
+            user_pool_email=user_pool_email_settings,
+            removal_policy=removal_policy
+        )
+
         if self.hosted_zone:
-            # The SES email identity needs to be created before the user pool
+            # The SES email identity needs to be created before the user pools
             # so that the domain address will be verified before being referenced
             # by the user pool email settings
             self.staff_users.node.add_dependency(self.user_email_notifications)
+            self.provider_users.node.add_dependency(self.user_email_notifications)
 
     def _add_mock_data_resources(self):
         self.mock_bulk_uploads_bucket = BulkUploadsBucket(

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from aws_cdk.aws_cognito import UserPoolEmail
+from aws_cdk.aws_kms import IKey
+from constructs import Construct
+
+from common_constructs.user_pool import UserPool
+from stacks import persistent_stack as ps
+
+
+class ProviderUsers(UserPool):
+    """
+    User pool for medical providers (aka Licensees)
+    """
+    def __init__(
+            self, scope: Construct, construct_id: str, *,
+            cognito_domain_prefix: str,
+            environment_name: str,
+            environment_context: dict,
+            encryption_key: IKey,
+            user_pool_email: UserPoolEmail,
+            removal_policy,
+            **kwargs
+    ):
+        super().__init__(
+            scope, construct_id,
+            cognito_domain_prefix=cognito_domain_prefix,
+            environment_name=environment_name,
+            encryption_key=encryption_key,
+            removal_policy=removal_policy,
+            email=user_pool_email,
+            **kwargs
+        )
+        stack: ps.PersistentStack = ps.PersistentStack.of(self)
+
+        callback_urls = []
+        if stack.ui_domain_name is not None:
+            callback_urls.append(f'https://{stack.ui_domain_name}/auth/callback')
+        # This toggle will allow front-end devs to point their local UI at this environment's user pool to support
+        # authenticated actions.
+        if environment_context.get('allow_local_ui', False):
+            local_ui_port = environment_context.get('local_ui_port', '3018')
+            callback_urls.append(f'http://localhost:{local_ui_port}/auth/callback')
+        if not callback_urls:
+            raise ValueError(
+                "This app requires a callback url for its authentication path. Either provide 'domain_name' or set "
+                "'allow_local_ui' to true in this environment's context.")
+
+        # Create an app client to allow the front-end to authenticate.
+        self.ui_client = self.add_ui_client(callback_urls=callback_urls)


### PR DESCRIPTION
We need to have a separate user pool to track licensee users (AKA providers).

### Requirements List
-

### Description List
-

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review
- ???

Closes #
