### PR TITLE
Feat/add provider user me endpoint

### DIFF
--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -89,7 +89,7 @@ class UserPool(CdkUserPool):
         """
         Creates an app client for the UI to authenticate with the user pool.
 
-        :param callback_urls: The URLs that Cognito will redirect to after authentication.
+        :param callback_urls: The URLs that Cognito allows the UI to redirect to after authentication.
         :param read_attributes: The attributes that the UI can read.
         :param write_attributes: The attributes that the UI can write.
         :param ui_scopes: OAuth scopes that are allowed with this client

--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -3,7 +3,7 @@ from typing import List
 from aws_cdk import CfnOutput, Duration, RemovalPolicy
 from aws_cdk.aws_cognito import UserPool as CdkUserPool, UserPoolEmail, AccountRecovery, AutoVerifiedAttrs, \
     AdvancedSecurityMode, DeviceTracking, Mfa, MfaSecondFactor, PasswordPolicy, StandardAttributes, \
-    StandardAttribute, CognitoDomainOptions, AuthFlow, OAuthSettings, OAuthFlows, ClientAttributes, \
+    CognitoDomainOptions, AuthFlow, OAuthSettings, OAuthFlows, ClientAttributes, \
     CfnUserPoolRiskConfigurationAttachment, OAuthScope
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions

--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -81,7 +81,19 @@ class UserPool(CdkUserPool):
             ]
         )
 
-    def add_ui_client(self, callback_urls: List[str], ui_scopes: List[OAuthScope] = None):
+    def add_ui_client(self,
+                      callback_urls: List[str],
+                      read_attributes: ClientAttributes,
+                      write_attributes: ClientAttributes,
+                      ui_scopes: List[OAuthScope] = None):
+        """
+        Creates an app client for the UI to authenticate with the user pool.
+
+        :param callback_urls: The URLs that Cognito will redirect to after authentication.
+        :param read_attributes: The attributes that the UI can read.
+        :param write_attributes: The attributes that the UI can write.
+        :param ui_scopes: OAuth scopes that are allowed with this client
+        """
         return self.add_client(
             'UIClient',
             auth_flows=AuthFlow(
@@ -103,11 +115,8 @@ class UserPool(CdkUserPool):
             enable_token_revocation=True,
             generate_secret=False,
             refresh_token_validity=Duration.days(30),
-            # If you provide no attributes at all here, it will default
-            # to making _all_ attributes writeable, so if we want to limit writes,
-            # we have to provide at least _one_ that the client _can_ write.
-            write_attributes=ClientAttributes().with_standard_attributes(email=True),
-            read_attributes=ClientAttributes().with_standard_attributes(email=True)
+            read_attributes=read_attributes,
+            write_attributes=write_attributes,
         )
 
     def _add_risk_configuration(self):

--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -17,6 +17,7 @@ class UserPool(CdkUserPool):
             environment_name: str,
             encryption_key: IKey,
             email: UserPoolEmail,
+            standard_attributes: StandardAttributes,
             removal_policy,
             **kwargs
     ):
@@ -42,12 +43,7 @@ class UserPool(CdkUserPool):
             self_sign_up_enabled=False,
             sign_in_aliases=None,
             sign_in_case_sensitive=False,
-            standard_attributes=StandardAttributes(
-                email=StandardAttribute(
-                    mutable=False,
-                    required=True
-                )
-            ),
+            standard_attributes=standard_attributes,
             **kwargs
         )
 

--- a/backend/compact-connect/common_constructs/user_pool.py
+++ b/backend/compact-connect/common_constructs/user_pool.py
@@ -1,10 +1,10 @@
-from typing import List
+from typing import List, Optional, Mapping
 
 from aws_cdk import CfnOutput, Duration, RemovalPolicy
 from aws_cdk.aws_cognito import UserPool as CdkUserPool, UserPoolEmail, AccountRecovery, AutoVerifiedAttrs, \
     AdvancedSecurityMode, DeviceTracking, Mfa, MfaSecondFactor, PasswordPolicy, StandardAttributes, \
     CognitoDomainOptions, AuthFlow, OAuthSettings, OAuthFlows, ClientAttributes, \
-    CfnUserPoolRiskConfigurationAttachment, OAuthScope
+    CfnUserPoolRiskConfigurationAttachment, OAuthScope, ICustomAttribute
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions
 from constructs import Construct
@@ -19,6 +19,7 @@ class UserPool(CdkUserPool):
             email: UserPoolEmail,
             standard_attributes: StandardAttributes,
             removal_policy,
+            custom_attributes: Optional[Mapping[str, ICustomAttribute]] = None,
             **kwargs
     ):
         super().__init__(
@@ -44,6 +45,7 @@ class UserPool(CdkUserPool):
             sign_in_aliases=None,
             sign_in_case_sensitive=False,
             standard_attributes=standard_attributes,
+            custom_attributes=custom_attributes,
             **kwargs
         )
 

--- a/backend/compact-connect/docs/api-specification/latest-oas30.json
+++ b/backend/compact-connect/docs/api-specification/latest-oas30.json
@@ -288,6 +288,58 @@
         }
       }
     },
+    "/v1/provider-users/me" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200 response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SandboLicenoQX8XMkCWBE3"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "SandboxAPIStackLicenseApiProviderUsersPoolAuthorizerEB7523BA" : [ ]
+        } ]
+      },
+      "options" : {
+        "responses" : {
+          "204" : {
+            "description" : "204 response",
+            "headers" : {
+              "Access-Control-Allow-Origin" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              },
+              "Access-Control-Allow-Methods" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              },
+              "Access-Control-Allow-Headers" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : { }
+          }
+        }
+      }
+    },
     "/v1/compacts/{compact}/providers" : {
       "options" : {
         "consumes" : [ "application/json" ],

--- a/backend/compact-connect/docs/api-specification/latest-oas30.json
+++ b/backend/compact-connect/docs/api-specification/latest-oas30.json
@@ -304,7 +304,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/SandboLicenoQX8XMkCWBE3"
+                  "$ref" : "#/definitions/SandboLicenCdZUBqRikZnZ"
                 }
               }
             }

--- a/backend/compact-connect/lambdas/provider-data-v1/handlers/__init__.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/handlers/__init__.py
@@ -1,0 +1,44 @@
+from config import config, logger
+from exceptions import CCInternalException
+
+
+
+def get_provider_information(compact: str, provider_id: str) -> dict:
+    """
+    Common method to get provider information by compact and provider id.
+
+    Currently, this is used by both staff-users to get information for a specific provider,
+    and provider-users to get their own information.
+
+    :param compact: Compact the provider belongs to.
+    :param provider_id: The provider's unique identifier.
+    :return: Provider profile information.
+    """
+    provider_data = config.data_client.get_provider(compact=compact, provider_id=provider_id)
+    # This is really unlikely, but will check anyway
+    last_key = provider_data['pagination'].get('lastKey')
+    if last_key is not None:
+        logger.error('A provider had so many records, they paginated!')
+        raise CCInternalException('Unexpected provider data')
+
+    provider = None
+    privileges = []
+    licenses = []
+    for record in provider_data['items']:
+        match record['type']:
+            case 'provider':
+                logger.debug('Identified provider record', provider_id=provider_id)
+                provider = record
+            case 'license':
+                logger.debug('Identified license record', provider_id=provider_id)
+                licenses.append(record)
+            case 'privilege':
+                logger.debug('Identified privilege record', provider_id=provider_id)
+                privileges.append(record)
+    if provider is None:
+        logger.error("Failed to find a provider's primary record!", provider_id=provider_id)
+        raise CCInternalException('Unexpected provider data')
+
+    provider['licenses'] = licenses
+    provider['privileges'] = privileges
+    return provider

--- a/backend/compact-connect/lambdas/provider-data-v1/handlers/provider_users.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/handlers/provider_users.py
@@ -20,7 +20,7 @@ def get_provider(event: dict, context: LambdaContext):  # pylint: disable=unused
         # the two values for compact and providerId are stored as custom attributes in the user's cognito claims
         # so we can access them directly from the event object
         compact = event['requestContext']['authorizer']['claims']['custom:compact']
-        provider_id = event['requestContext']['authorizer']['claims']['custom:compact']
+        provider_id = event['requestContext']['authorizer']['claims']['custom:providerId']
     except (KeyError, TypeError) as e:
         # This shouldn't happen unless a provider user was created without these custom attributes,
         # but we'll handle it, anyway

--- a/backend/compact-connect/lambdas/provider-data-v1/handlers/provider_users.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/handlers/provider_users.py
@@ -1,0 +1,30 @@
+# pylint: disable=unused-argument,unexpected-keyword-arg,missing-kwoa
+# Pylint really butchers these function signatures because they are modified via decorator
+# to cut down on noise level, we're disabling those rules for the whole module
+
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+from exceptions import CCInvalidRequestException
+from handlers.utils import api_handler, authorize_compact
+from config import logger
+from . import get_provider_information
+
+@api_handler
+def get_provider(event: dict, context: LambdaContext):  # pylint: disable=unused-argument
+    """
+    Return one provider's data
+    :param event: Standard API Gateway event, API schema documented in the CDK ApiStack
+    :param LambdaContext context:
+    """
+    try:
+        # the two values for compact and providerId are stored as custom attributes in the user's cognito claims
+        # so we can access them directly from the event object
+        compact = event['requestContext']['authorizer']['claims']['custom:compact']
+        provider_id = event['requestContext']['authorizer']['claims']['custom:compact']
+    except (KeyError, TypeError) as e:
+        # This shouldn't happen unless a provider user was created without these custom attributes,
+        # but we'll handle it, anyway
+        logger.error(f'Missing custom provider attribute: {e}')
+        raise CCInvalidRequestException('Missing required user profile attribute') from e
+
+    return get_provider_information(compact=compact, provider_id=provider_id)

--- a/backend/compact-connect/lambdas/provider-data-v1/handlers/provider_users.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/handlers/provider_users.py
@@ -10,7 +10,7 @@ from config import logger
 from . import get_provider_information
 
 @api_handler
-def get_provider(event: dict, context: LambdaContext):  # pylint: disable=unused-argument
+def get_provider_user_me(event: dict, context: LambdaContext):  # pylint: disable=unused-argument
     """
     Endpoint for a provider user to fetch their personal provider data.
 

--- a/backend/compact-connect/lambdas/provider-data-v1/handlers/providers.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/handlers/providers.py
@@ -5,9 +5,10 @@ import json
 
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
-from exceptions import CCInvalidRequestException, CCInternalException
+from exceptions import CCInvalidRequestException
 from handlers.utils import api_handler, authorize_compact
 from config import config, logger
+from . import get_provider_information
 
 
 @api_handler
@@ -102,31 +103,4 @@ def get_provider(event: dict, context: LambdaContext):  # pylint: disable=unused
         logger.error(f'Missing parameter: {e}')
         raise CCInvalidRequestException('Missing required field') from e
 
-    provider_data = config.data_client.get_provider(compact=compact, provider_id=provider_id)
-    # This is really unlikely, but will check anyway
-    last_key = provider_data['pagination'].get('lastKey')
-    if last_key is not None:
-        logger.error('A provider had so many records, they paginated!')
-        raise CCInternalException('Unexpected provider data')
-
-    provider = None
-    privileges = []
-    licenses = []
-    for record in provider_data['items']:
-        match record['type']:
-            case 'provider':
-                logger.debug('Identified provider record', provider_id=provider_id)
-                provider = record
-            case 'license':
-                logger.debug('Identified license record', provider_id=provider_id)
-                licenses.append(record)
-            case 'privilege':
-                logger.debug('Identified privilege record', provider_id=provider_id)
-                privileges.append(record)
-    if provider is None:
-        logger.error("Failed to find a provider's primary record!", provider_id=provider_id)
-        raise CCInternalException('Unexpected provider data')
-
-    provider['licenses'] = licenses
-    provider['privileges'] = privileges
-    return provider
+    return get_provider_information(compact=compact, provider_id=provider_id)

--- a/backend/compact-connect/lambdas/provider-data-v1/handlers/utils.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/handlers/utils.py
@@ -98,15 +98,6 @@ def api_handler(fn: Callable):
                 'statusCode': 404,
                 'body': json.dumps({'message': 'Resource not found'})
             }
-        except CCInternalException as e:
-            logger.info('Internal Error', exc_info=e)
-            return {
-                'headers': {
-                    'Access-Control-Allow-Origin': '*'
-                },
-                'statusCode': 500,
-                'body': json.dumps({'message': 'Internal server error'})
-            }
         except CCInvalidRequestException as e:
             logger.info('Invalid request', exc_info=e)
             return {

--- a/backend/compact-connect/lambdas/provider-data-v1/handlers/utils.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/handlers/utils.py
@@ -10,7 +10,8 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from botocore.exceptions import ClientError
 
 from config import logger
-from exceptions import CCInvalidRequestException, CCUnauthorizedException, CCAccessDeniedException
+from exceptions import CCInvalidRequestException, CCUnauthorizedException, CCAccessDeniedException, CCNotFoundException, \
+    CCInternalException
 
 
 class ResponseEncoder(JSONEncoder):
@@ -87,6 +88,24 @@ def api_handler(fn: Callable):
                 },
                 'statusCode': 403,
                 'body': json.dumps({'message': 'Access denied'})
+            }
+        except CCNotFoundException as e:
+            logger.info('Resource not found', exc_info=e)
+            return {
+                'headers': {
+                    'Access-Control-Allow-Origin': '*'
+                },
+                'statusCode': 404,
+                'body': json.dumps({'message': 'Resource not found'})
+            }
+        except CCInternalException as e:
+            logger.info('Internal Error', exc_info=e)
+            return {
+                'headers': {
+                    'Access-Control-Allow-Origin': '*'
+                },
+                'statusCode': 500,
+                'body': json.dumps({'message': 'Internal server error'})
             }
         except CCInvalidRequestException as e:
             logger.info('Invalid request', exc_info=e)

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_provider_users.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_provider_users.py
@@ -2,6 +2,7 @@ import json
 
 from moto import mock_aws
 from tests.function import TstFunction
+from exceptions import CCInternalException
 
 TEST_COMPACT = "aslp"
 MOCK_SSN = "123-12-1234"
@@ -62,6 +63,5 @@ class TestGetProvider(TstFunction):
             event = json.load(f)
 
         # calling get_provider without creating a provider first
-        resp = get_provider(event, self.mock_context)
-
-        self.assertEqual(500, resp['statusCode'])
+        with self.assertRaises(CCInternalException):
+            get_provider_user_me(event, self.mock_context)

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_provider_users.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_provider_users.py
@@ -1,0 +1,40 @@
+import json
+
+from moto import mock_aws
+from tests.function import TstFunction
+
+TEST_COMPACT = "aslp"
+MOCK_SSN = "123-12-1234"
+@mock_aws
+class TestGetProvider(TstFunction):
+
+    def _create_test_provider(self):
+        from config import config
+        provider_id = config.data_client.get_or_create_provider_id(compact=TEST_COMPACT, ssn=MOCK_SSN)
+
+        return provider_id
+
+    def test_get_provider(self):
+        """
+        Provider detail response
+        """
+        self._load_provider_data()
+
+        from handlers.provider_users import get_provider
+
+        with open('tests/resources/provider-user-api-event.json', 'r') as f:
+            event = json.load(f)
+
+        with open('tests/resources/api/provider-detail-response.json', 'r') as f:
+            expected_provider = json.load(f)
+
+        provider_id = self._create_test_provider()
+        # set custom attributes in the cognito claims
+        event['requestContext']['authorizer']['claims']['custom:providerId'] = provider_id
+        event['requestContext']['authorizer']['claims']['custom:compact'] = TEST_COMPACT
+
+        resp = get_provider(event, self.mock_context)
+
+        self.assertEqual(200, resp['statusCode'])
+        provider_data = json.loads(resp['body'])
+        self.assertEqual(expected_provider, provider_data)

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_provider_users.py
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/function/test_handlers/test_provider_users.py
@@ -17,7 +17,7 @@ class TestGetProvider(TstFunction):
     def test_get_provider_returns_provider_information(self):
         self._load_provider_data()
 
-        from handlers.provider_users import get_provider
+        from handlers.provider_users import get_provider_user_me
 
         with open('tests/resources/provider-user-api-event.json', 'r') as f:
             event = json.load(f)
@@ -30,7 +30,7 @@ class TestGetProvider(TstFunction):
         event['requestContext']['authorizer']['claims']['custom:providerId'] = provider_id
         event['requestContext']['authorizer']['claims']['custom:compact'] = TEST_COMPACT
 
-        resp = get_provider(event, self.mock_context)
+        resp = get_provider_user_me(event, self.mock_context)
 
         self.assertEqual(200, resp['statusCode'])
         provider_data = json.loads(resp['body'])
@@ -40,7 +40,7 @@ class TestGetProvider(TstFunction):
     def test_get_provider_returns_400_if_api_call_made_without_proper_claims(self):
         self._load_provider_data()
 
-        from handlers.provider_users import get_provider
+        from handlers.provider_users import get_provider_user_me
 
         with open('tests/resources/provider-user-api-event.json', 'r') as f:
             event = json.load(f)
@@ -49,14 +49,14 @@ class TestGetProvider(TstFunction):
         del event['requestContext']['authorizer']['claims']['custom:providerId']
         del event['requestContext']['authorizer']['claims']['custom:compact']
 
-        resp = get_provider(event, self.mock_context)
+        resp = get_provider_user_me(event, self.mock_context)
 
         self.assertEqual(400, resp['statusCode'])
 
-    def test_get_provider_returns_500_if_user_claims_do_not_match_any_provider_in_database(self):
+    def test_get_provider_raises_exception_if_user_claims_do_not_match_any_provider_in_database(self):
         self._load_provider_data()
 
-        from handlers.provider_users import get_provider
+        from handlers.provider_users import get_provider_user_me
 
         with open('tests/resources/provider-user-api-event.json', 'r') as f:
             event = json.load(f)

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/resources/provider-user-api-event.json
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/resources/provider-user-api-event.json
@@ -1,0 +1,142 @@
+{
+    "resource": "/v1/provider-users/me",
+    "path": "/v1/provider-users/me",
+    "httpMethod": "GET",
+    "headers": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Authorization": "Bearer eyfoofoo",
+        "Cache-Control": "no-cache",
+        "CloudFront-Forwarded-Proto": "https",
+        "CloudFront-Is-Desktop-Viewer": "true",
+        "CloudFront-Is-Mobile-Viewer": "false",
+        "CloudFront-Is-SmartTV-Viewer": "false",
+        "CloudFront-Is-Tablet-Viewer": "false",
+        "CloudFront-Viewer-ASN": "14618",
+        "CloudFront-Viewer-Country": "US",
+        "Host": "xib7bpau43.execute-api.us-east-1.amazonaws.com",
+        "Postman-Token": "1eedab23-5dd2-40db-93e2-5c8007bd1f89",
+        "User-Agent": "PostmanRuntime/7.36.1",
+        "Via": "1.1 f0f1092b2ad1f0e573a4fcbefe4fb620.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Id": "QHDmaz0LJQgmM6R7BcPxdn_AOzrvklxaAQWMFIp6vU5iC00sOenZeA==",
+        "X-Amzn-Trace-Id": "Root=1-65bd6123-0212598f4d09694c1f4bb8fe",
+        "X-Forwarded-For": "54.86.50.139, 70.132.32.86",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https"
+    },
+    "multiValueHeaders": {
+        "Accept": [
+            "*/*"
+        ],
+        "Accept-Encoding": [
+            "gzip, deflate, br"
+        ],
+        "Authorization": [
+            "Bearer eyfoofoo"
+        ],
+        "Cache-Control": [
+            "no-cache"
+        ],
+        "CloudFront-Forwarded-Proto": [
+            "https"
+        ],
+        "CloudFront-Is-Desktop-Viewer": [
+            "true"
+        ],
+        "CloudFront-Is-Mobile-Viewer": [
+            "false"
+        ],
+        "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+        ],
+        "CloudFront-Is-Tablet-Viewer": [
+            "false"
+        ],
+        "CloudFront-Viewer-ASN": [
+            "14618"
+        ],
+        "CloudFront-Viewer-Country": [
+            "US"
+        ],
+        "Host": [
+            "xib7bpau43.execute-api.us-east-1.amazonaws.com"
+        ],
+        "Postman-Token": [
+            "1eedab23-5dd2-40db-93e2-5c8007bd1f89"
+        ],
+        "User-Agent": [
+            "PostmanRuntime/7.36.1"
+        ],
+        "Via": [
+            "1.1 f0f1092b2ad1f0e573a4fcbefe4fb620.cloudfront.net (CloudFront)"
+        ],
+        "X-Amz-Cf-Id": [
+            "QHDmaz0LJQgmM6R7BcPxdn_AOzrvklxaAQWMFIp6vU5iC00sOenZeA=="
+        ],
+        "X-Amzn-Trace-Id": [
+            "Root=1-65bd6123-0212598f4d09694c1f4bb8fe"
+        ],
+        "X-Forwarded-For": [
+            "54.86.50.139, 70.132.32.86"
+        ],
+        "X-Forwarded-Port": [
+            "443"
+        ],
+        "X-Forwarded-Proto": [
+            "https"
+        ]
+    },
+    "queryStringParameters": null,
+    "multiValueQueryStringParameters": null,
+    "pathParameters": null,
+    "stageVariables": null,
+    "requestContext": {
+        "resourceId": "niuigd",
+        "authorizer": {
+            "claims": {
+                "sub": "4kq74be0isgt7shnhhfgi5dk9k",
+                "token_use": "access",
+                "scope": "openid email profile",
+                "auth_time": "1717782706",
+                "custom:compact": "al",
+                "custom:providerId": "some-provider-id",
+                "iss": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_xS47lbscb",
+                "exp": "Fri Jun 07 18:51:46 UTC 2024",
+                "iat": "Fri Jun 07 17:51:46 UTC 2024",
+                "version": "2",
+                "jti": "b4490af3-478f-49a9-90f5-373886ebe5c2",
+                "client_id": "4kq74be0isgt7shnhhfgi5dk9k"
+            }
+        },
+        "resourcePath": "/v0/boards/{jurisdiction}/licenses/bulk-upload",
+        "httpMethod": "GET",
+        "extendedRequestId": "ZAmXuH9bIAMEjZA=",
+        "requestTime": "07/Jun/2024:18:27:09 +0000",
+        "path": "/sandbox/v0/boards/al/licenses/bulk-upload",
+        "accountId": "058264452476",
+        "protocol": "HTTP/1.1",
+        "stage": "sandbox",
+        "domainPrefix": "j9hs0bq9i9",
+        "requestTimeEpoch": 1717784829944,
+        "requestId": "6003a0c9-c61c-4d83-a2df-963e51f1a82f",
+        "identity": {
+            "cognitoIdentityPoolId": null,
+            "accountId": null,
+            "cognitoIdentityId": null,
+            "caller": null,
+            "sourceIp": "54.86.50.139",
+            "principalOrgId": null,
+            "accessKey": null,
+            "cognitoAuthenticationType": null,
+            "cognitoAuthenticationProvider": null,
+            "userArn": null,
+            "userAgent": "PostmanRuntime/7.39.0",
+            "user": null
+        },
+        "domainName": "j9hs0bq9i9.execute-api.us-east-1.amazonaws.com",
+        "deploymentId": "okxjb3",
+        "apiId": "j9hs0bq9i9"
+    },
+    "body": null,
+    "isBase64Encoded": false
+}

--- a/backend/compact-connect/lambdas/provider-data-v1/tests/resources/provider-user-api-event.json
+++ b/backend/compact-connect/lambdas/provider-data-v1/tests/resources/provider-user-api-event.json
@@ -98,7 +98,7 @@
                 "token_use": "access",
                 "scope": "openid email profile",
                 "auth_time": "1717782706",
-                "custom:compact": "al",
+                "custom:compact": "aslp",
                 "custom:providerId": "some-provider-id",
                 "iss": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_xS47lbscb",
                 "exp": "Fri Jun 07 18:51:46 UTC 2024",

--- a/backend/compact-connect/stacks/api_stack/cc_api.py
+++ b/backend/compact-connect/stacks/api_stack/cc_api.py
@@ -248,6 +248,13 @@ class CCApi(RestApi):
         )
 
     @cached_property
+    def provider_users_authorizer(self):
+        return CognitoUserPoolsAuthorizer(
+            self, 'ProviderUsersPoolAuthorizer',
+            cognito_user_pools=[self._persistent_stack.provider_users]
+        )
+
+    @cached_property
     def parameter_body_validator(self):
         return self.add_request_validator(
             'BodyValidator',

--- a/backend/compact-connect/stacks/api_stack/v1_api/api.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/api.py
@@ -6,6 +6,7 @@ from stacks import persistent_stack as ps
 from stacks.api_stack import cc_api
 from stacks.api_stack.v1_api.bulk_upload_url import BulkUploadUrl
 from stacks.api_stack.v1_api.query_providers import QueryProviders
+from stacks.api_stack.v1_api.provider_users import ProviderUsers
 
 from .post_licenses import PostLicenses
 
@@ -36,6 +37,15 @@ class V1Api:
             authorization_type=AuthorizationType.COGNITO,
             authorizer=self.api.staff_users_authorizer,
             authorization_scopes=write_scopes
+        )
+
+        # /v1/provider-users/me
+        self.provider_users_resource = self.resource.add_resource('provider-users')
+        provider_users_me_resource = self.provider_users_resource.add_resource('me')
+        ProviderUsers(
+            provider_users_me_resource,
+            data_encryption_key=persistent_stack.shared_encryption_key,
+            provider_data_table=persistent_stack.provider_table
         )
 
         # /v1/compacts/{compact}

--- a/backend/compact-connect/stacks/api_stack/v1_api/provider_users.py
+++ b/backend/compact-connect/stacks/api_stack/v1_api/provider_users.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+
+from aws_cdk import Duration
+from aws_cdk.aws_apigateway import Resource, MethodResponse, Model, LambdaIntegration
+from aws_cdk.aws_kms import IKey
+from cdk_nag import NagSuppressions
+
+from common_constructs.python_function import PythonFunction
+from common_constructs.stack import Stack
+# Importing module level to allow lazy loading for typing
+from stacks.api_stack import cc_api
+from stacks.persistent_stack import ProviderTable
+
+
+class ProviderUsers:
+    def __init__(
+            self,
+            resource: Resource,
+            data_encryption_key: IKey,
+            provider_data_table: ProviderTable
+    ):
+        super().__init__()
+
+        self.resource = resource
+        self.api: cc_api.CCApi = resource.api
+
+        stack: Stack = Stack.of(resource)
+        lambda_environment = {
+            'PROVIDER_TABLE_NAME': provider_data_table.table_name,
+            'PROV_FAM_GIV_MID_INDEX_NAME': 'providerFamGivMid',
+            'PROV_DATE_OF_UPDATE_INDEX_NAME': 'providerDateOfUpdate',
+            **stack.common_env_vars
+        }
+
+        self._add_get_provider_user_me(
+            data_encryption_key=data_encryption_key,
+            provider_data_table=provider_data_table,
+            lambda_environment=lambda_environment
+        )
+
+    def _add_get_provider_user_me(
+            self,
+            data_encryption_key: IKey,
+            provider_data_table: ProviderTable,
+            lambda_environment: dict
+    ):
+        handler = self._get_provider_user_me_handler(
+            data_encryption_key=data_encryption_key,
+            provider_data_table=provider_data_table,
+            lambda_environment=lambda_environment
+        )
+        self.api.log_groups.append(handler.log_group)
+
+        self.resource.add_method(
+            'GET',
+            request_validator=self.api.parameter_body_validator,
+            method_responses=[
+                MethodResponse(
+                    status_code='200',
+                    response_models={
+                        'application/json': self._get_provider_response_model()
+                    }
+                )
+            ],
+            integration=LambdaIntegration(
+                handler,
+                timeout=Duration.seconds(29)
+            ),
+            request_parameters={
+                'method.request.header.Authorization': True
+            },
+            authorizer=self.api.provider_users_authorizer,
+        )
+
+
+    def _get_provider_response_model(self) -> Model:
+        """
+        Return the query license response model, which should only be created once per API
+        """
+        if hasattr(self.api, 'v1_get_provider_response_model'):
+            return self.api.v1_get_provider_response_model
+        self.api.v1_get_provider_response_model = self.api.add_model(
+            'V1GetProviderResponseModel',
+            description='Get provider response model',
+            schema=self.api.v1_provider_detail_response_schema
+        )
+        return self.api.v1_get_provider_response_model
+
+
+    def _get_provider_user_me_handler(
+            self,
+            data_encryption_key: IKey,
+            provider_data_table: ProviderTable,
+            lambda_environment: dict
+    ) -> PythonFunction:
+        stack = Stack.of(self.resource)
+        handler = PythonFunction(
+            self.resource, 'GetProviderUserMeHandler',
+            description='Get provider personal profile information handler',
+            entry=os.path.join('lambdas', 'provider-data-v1'),
+            index=os.path.join('handlers', 'provider_users.py'),
+            handler='get_provider_user_me',
+            environment=lambda_environment,
+            alarm_topic=self.api.alarm_topic
+        )
+        data_encryption_key.grant_decrypt(handler)
+        provider_data_table.grant_read_data(handler)
+
+        NagSuppressions.add_resource_suppressions_by_path(
+            stack,
+            path=f'{handler.node.path}/ServiceRole/DefaultPolicy/Resource',
+            suppressions=[
+                {
+                    'id': 'AwsSolutions-IAM5',
+                    'reason': 'The actions in this policy are specifically what this lambda needs to read '
+                              'and is scoped to one table and encryption key.'
+                }
+            ]
+        )
+        return handler

--- a/backend/compact-connect/stacks/persistent_stack/__init__.py
+++ b/backend/compact-connect/stacks/persistent_stack/__init__.py
@@ -12,6 +12,7 @@ from stacks.persistent_stack.license_table import LicenseTable
 from stacks.persistent_stack.event_bus import EventBus
 from stacks.persistent_stack.provider_table import ProviderTable
 from stacks.persistent_stack.staff_users import StaffUsers
+from stacks.persistent_stack.provider_users import ProviderUsers
 from stacks.persistent_stack.user_email_notifications import UserEmailNotifications
 
 # cdk leverages instance attributes to make resource exports accessible to other stacks
@@ -90,11 +91,25 @@ class PersistentStack(AppStack):
             user_pool_email=user_pool_email_settings,
             removal_policy=removal_policy
         )
+
+        provider_prefix = f'{app_name}-provider'
+        self.provider_users = ProviderUsers(
+            self, 'ProviderUsers',
+            cognito_domain_prefix=provider_prefix if environment_name == 'prod'
+            else f'{provider_prefix}-{environment_name}',
+            environment_name=environment_name,
+            environment_context=environment_context,
+            encryption_key=self.shared_encryption_key,
+            user_pool_email=user_pool_email_settings,
+            removal_policy=removal_policy
+        )
+
         if self.hosted_zone:
-            # The SES email identity needs to be created before the user pool
+            # The SES email identity needs to be created before the user pools
             # so that the domain address will be verified before being referenced
             # by the user pool email settings
             self.staff_users.node.add_dependency(self.user_email_notifications)
+            self.provider_users.node.add_dependency(self.user_email_notifications)
 
     def _add_mock_data_resources(self):
         self.mock_bulk_uploads_bucket = BulkUploadsBucket(

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -32,8 +32,10 @@ class ProviderUsers(UserPool):
             email=user_pool_email,
             standard_attributes=_configure_user_pool_standard_attributes(),
             custom_attributes={
-                # once the providerId is set, it cannot be changed
-                "providerId": StringAttribute(mutable=False)
+                # these fields are required in order for the provider to be able to query
+                # for their personal profile information. Once these fields are set, they cannot be changed.
+                "providerId": StringAttribute(mutable=False),
+                "compact": StringAttribute(mutable=False)
             },
             **kwargs
         )
@@ -56,10 +58,10 @@ class ProviderUsers(UserPool):
         self.ui_client = self.add_ui_client(
             callback_urls=callback_urls,
             # For now, we are allowing the user to read and update their email, given name, and family name.
-            # we only allow the user to be able to see their providerId, which is a custom attribute.
+            # we only allow the user to be able to see their providerId and compact, which are custom attributes.
             # If we ever want other attributes to be read or written, they must be added here.
             read_attributes=ClientAttributes().with_standard_attributes(email=True, given_name=True, family_name=True)
-                                              .with_custom_attributes("providerId"),
+                                              .with_custom_attributes("providerId", "compact"),
             write_attributes=ClientAttributes().with_standard_attributes(email=True, given_name=True, family_name=True)
         )
 

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from aws_cdk.aws_cognito import UserPoolEmail, StandardAttributes, StandardAttribute, ClientAttributes
+from aws_cdk.aws_cognito import UserPoolEmail, StandardAttributes, StandardAttribute, ClientAttributes, StringAttribute
 from aws_cdk.aws_kms import IKey
 from constructs import Construct
 
@@ -31,6 +31,10 @@ class ProviderUsers(UserPool):
             removal_policy=removal_policy,
             email=user_pool_email,
             standard_attributes=_configure_user_pool_standard_attributes(),
+            custom_attributes={
+                # once the providerId is set, it cannot be changed
+                "providerId": StringAttribute(mutable=False)
+            },
             **kwargs
         )
         stack: ps.PersistentStack = ps.PersistentStack.of(self)
@@ -52,8 +56,10 @@ class ProviderUsers(UserPool):
         self.ui_client = self.add_ui_client(
             callback_urls=callback_urls,
             # For now, we are allowing the user to read and update their email, given name, and family name.
+            # we only allow the user to be able to see their providerId, which is a custom attribute.
             # If we ever want other attributes to be read or written, they must be added here.
-            read_attributes=ClientAttributes().with_standard_attributes(email=True, given_name=True, family_name=True),
+            read_attributes=ClientAttributes().with_standard_attributes(email=True, given_name=True, family_name=True)
+                                              .with_custom_attributes("providerId"),
             write_attributes=ClientAttributes().with_standard_attributes(email=True, given_name=True, family_name=True)
         )
 

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from aws_cdk.aws_cognito import UserPoolEmail
+from aws_cdk.aws_kms import IKey
+from constructs import Construct
+
+from common_constructs.user_pool import UserPool
+from stacks import persistent_stack as ps
+
+
+class ProviderUsers(UserPool):
+    """
+    User pool for medical providers (aka Licensees)
+    """
+    def __init__(
+            self, scope: Construct, construct_id: str, *,
+            cognito_domain_prefix: str,
+            environment_name: str,
+            environment_context: dict,
+            encryption_key: IKey,
+            user_pool_email: UserPoolEmail,
+            removal_policy,
+            **kwargs
+    ):
+        super().__init__(
+            scope, construct_id,
+            cognito_domain_prefix=cognito_domain_prefix,
+            environment_name=environment_name,
+            encryption_key=encryption_key,
+            removal_policy=removal_policy,
+            email=user_pool_email,
+            **kwargs
+        )
+        stack: ps.PersistentStack = ps.PersistentStack.of(self)
+
+        callback_urls = []
+        if stack.ui_domain_name is not None:
+            callback_urls.append(f'https://{stack.ui_domain_name}/auth/callback')
+        # This toggle will allow front-end devs to point their local UI at this environment's user pool to support
+        # authenticated actions.
+        if environment_context.get('allow_local_ui', False):
+            local_ui_port = environment_context.get('local_ui_port', '3018')
+            callback_urls.append(f'http://localhost:{local_ui_port}/auth/callback')
+        if not callback_urls:
+            raise ValueError(
+                "This app requires a callback url for its authentication path. Either provide 'domain_name' or set "
+                "'allow_local_ui' to true in this environment's context.")
+
+        # Create an app client to allow the front-end to authenticate.
+        self.ui_client = self.add_ui_client(callback_urls=callback_urls)

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -12,6 +12,7 @@ class ProviderUsers(UserPool):
     """
     User pool for medical providers (aka Licensees)
     """
+
     def __init__(
             self, scope: Construct, construct_id: str, *,
             cognito_domain_prefix: str,

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from aws_cdk.aws_cognito import UserPoolEmail
+from aws_cdk.aws_cognito import UserPoolEmail, StandardAttributes, StandardAttribute
 from aws_cdk.aws_kms import IKey
 from constructs import Construct
 
@@ -29,6 +29,12 @@ class ProviderUsers(UserPool):
             encryption_key=encryption_key,
             removal_policy=removal_policy,
             email=user_pool_email,
+            standard_attributes=StandardAttributes(
+                email=StandardAttribute(
+                    mutable=False,
+                    required=True
+                )
+            ),
             **kwargs
         )
         stack: ps.PersistentStack = ps.PersistentStack.of(self)

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -64,14 +64,14 @@ def _configure_user_pool_standard_attributes() -> StandardAttributes:
 
         Note that these values can never change! If you need to make other attributes
         required in the future, you must create an entirely new user pool and migrate
-        existing users to the new pool. see https://repost.aws/knowledge-center/cognito-change-user-pool-attributes
+        existing users to the new pool. See https://repost.aws/knowledge-center/cognito-change-user-pool-attributes
 
         These attributes are used to display on a provider's profile page. We do not
         intend to use them for authentication purposes or for back-end processing.
     """
     return StandardAttributes(
         # We are requiring the following attributes for all users
-        # that are registered in the provider user pool
+        # that are registered in the provider user pool.
         email=StandardAttribute(
             mutable=True,
             required=True
@@ -84,7 +84,7 @@ def _configure_user_pool_standard_attributes() -> StandardAttributes:
             mutable=True,
             required=True
         ),
-        # the following attributes are not required, but we are including them because
+        # The following attributes are not required, but we are including them because
         # Cognito does not allow you to add them after the user pool is created, and we
         # may want to use them in the future.
         address=StandardAttribute(

--- a/backend/compact-connect/stacks/persistent_stack/provider_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/provider_users.py
@@ -29,12 +29,7 @@ class ProviderUsers(UserPool):
             encryption_key=encryption_key,
             removal_policy=removal_policy,
             email=user_pool_email,
-            standard_attributes=StandardAttributes(
-                email=StandardAttribute(
-                    mutable=False,
-                    required=True
-                )
-            ),
+            standard_attributes=_configure_user_pool_standard_attributes(),
             **kwargs
         )
         stack: ps.PersistentStack = ps.PersistentStack.of(self)
@@ -54,3 +49,88 @@ class ProviderUsers(UserPool):
 
         # Create an app client to allow the front-end to authenticate.
         self.ui_client = self.add_ui_client(callback_urls=callback_urls)
+
+
+def _configure_user_pool_standard_attributes() -> StandardAttributes:
+    """
+        The provider user pool standard attributes.
+
+        These attributes are used to display on a provider's profile page. We do not
+        intend to use them for authentication purposes or for back-end processing.
+    """
+    return StandardAttributes(
+        # We are requiring the following attributes for all users
+        # that are registered in the provider user pool
+        email=StandardAttribute(
+            mutable=True,
+            required=True
+        ),
+        given_name=StandardAttribute(
+            mutable=True,
+            required=True
+        ),
+        family_name=StandardAttribute(
+            mutable=True,
+            required=True
+        ),
+        # the following attributes are not required, but we are including them because
+        # Cognito does not allow you to add them after the user pool is created, and we
+        # may want to use them in the future.
+        # see https://repost.aws/knowledge-center/cognito-change-user-pool-attributes
+        address=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        birthdate=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        fullname=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        gender=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        last_update_time=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        locale=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        middle_name=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        nickname=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        phone_number=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        preferred_username=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        profile_page=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        profile_picture=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        timezone=StandardAttribute(
+            mutable=True,
+            required=False
+        ),
+        website=StandardAttribute(
+            mutable=True,
+            required=False
+        )
+    )

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -142,7 +142,7 @@ class StaffUsers(UserPool):
             suppressions=[{
                 'id': 'AwsSolutions-IAM5',
                 'reason': 'This lambda role policy contains wildcards in its statements, but all of its actions are '
-                          'limited specifically to the actions and the Table it needs read access to.'
+                'limited specifically to the actions and the Table it needs read access to.'
             }]
         )
         self.add_trigger(

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 import json
 import os
 
-from aws_cdk.aws_cognito import (ResourceServerScope, UserPoolOperation, LambdaVersion, UserPoolEmail,
-                                 StandardAttributes, StandardAttribute)
+from aws_cdk.aws_cognito import ResourceServerScope, UserPoolOperation, LambdaVersion, UserPoolEmail, \
+    StandardAttributes, StandardAttribute
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions
 from constructs import Construct
@@ -18,6 +18,7 @@ class StaffUsers(UserPool):
     """
     User pool for Compact, Board, and CSG staff
     """
+
     def __init__(
             self, scope: Construct, construct_id: str, *,
             cognito_domain_prefix: str,
@@ -136,7 +137,7 @@ class StaffUsers(UserPool):
             suppressions=[{
                 'id': 'AwsSolutions-IAM5',
                 'reason': 'This lambda role policy contains wildcards in its statements, but all of its actions are '
-                'limited specifically to the actions and the Table it needs read access to.'
+                          'limited specifically to the actions and the Table it needs read access to.'
             }]
         )
         self.add_trigger(

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -3,7 +3,7 @@ import json
 import os
 
 from aws_cdk.aws_cognito import ResourceServerScope, UserPoolOperation, LambdaVersion, UserPoolEmail, \
-    StandardAttributes, StandardAttribute
+    StandardAttributes, StandardAttribute, ClientAttributes
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions
 from constructs import Construct
@@ -70,7 +70,12 @@ class StaffUsers(UserPool):
 
         # Do not allow resource server scopes via the client - they are assigned via token customization
         # to allow for user attribute-based access
-        self.ui_client = self.add_ui_client(callback_urls=callback_urls)
+        self.ui_client = self.add_ui_client(
+            callback_urls=callback_urls,
+            # We want to limit the attributes that this app can read and write so only email is visible.
+            read_attributes=ClientAttributes().with_standard_attributes(email=True),
+            write_attributes=ClientAttributes().with_standard_attributes(email=True)
+        )
 
     def _add_resource_servers(self):
         """

--- a/backend/compact-connect/stacks/persistent_stack/staff_users.py
+++ b/backend/compact-connect/stacks/persistent_stack/staff_users.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 import json
 import os
 
-from aws_cdk.aws_cognito import ResourceServerScope, UserPoolOperation, LambdaVersion, UserPoolEmail
+from aws_cdk.aws_cognito import (ResourceServerScope, UserPoolOperation, LambdaVersion, UserPoolEmail,
+                                 StandardAttributes, StandardAttribute)
 from aws_cdk.aws_kms import IKey
 from cdk_nag import NagSuppressions
 from constructs import Construct
@@ -34,6 +35,12 @@ class StaffUsers(UserPool):
             encryption_key=encryption_key,
             removal_policy=removal_policy,
             email=user_pool_email,
+            standard_attributes=StandardAttributes(
+                email=StandardAttribute(
+                    mutable=False,
+                    required=True
+                )
+            ),
             **kwargs
         )
         stack: ps.PersistentStack = ps.PersistentStack.of(self)

--- a/backend/compact-connect/tests/unit/test_api.py
+++ b/backend/compact-connect/tests/unit/test_api.py
@@ -1,0 +1,68 @@
+import json
+from unittest import TestCase
+
+from aws_cdk.assertions import Template, Capture
+from aws_cdk.aws_apigateway import CfnResource
+from aws_cdk.aws_lambda import CfnFunction
+
+from app import CompactConnectApp
+
+
+class TestApi(TestCase):
+    """
+    These tests are focused on checking that the API stack is configured correctly.
+
+    When adding or modifying API resources, a test should be added to ensure that the
+    resource is created as expected.
+    """
+
+    def _when_testing_sandbox_stack_synth(self):
+        with open('cdk.json', 'r') as f:
+            context = json.load(f)['context']
+        with open('cdk.context.sandbox-example.json', 'r') as f:
+            context.update(json.load(f))
+
+        # Suppresses lambda bundling for tests
+        context['aws:cdk:bundling-stacks'] = []
+
+        app = CompactConnectApp(context=context)
+        api_stack_template = Template.from_stack(app.sandbox_stage.api_stack)
+
+        return api_stack_template
+
+
+    def test_synth_generates_provider_users_resource(self):
+        api_stack_template = self._when_testing_sandbox_stack_synth()
+
+        parent_id_capture = Capture()
+        # Ensure the resource is created with expected path
+        api_stack_template.has_resource_properties(
+            type=CfnResource.CFN_RESOURCE_TYPE_NAME,
+            props={
+                "ParentId": parent_id_capture,
+                "PathPart": "provider-users"
+            })
+
+        self.assertIn("LicenseApiv1", parent_id_capture.as_object()["Ref"])
+
+    def test_synth_generates_get_provider_users_me_endpoint_resource(self):
+        api_stack_template = self._when_testing_sandbox_stack_synth()
+
+        parent_id_capture = Capture()
+        # Ensure the resource is created with expected path
+        api_stack_template.has_resource_properties(
+            type=CfnResource.CFN_RESOURCE_TYPE_NAME,
+            props={
+                "ParentId": parent_id_capture,
+                "PathPart": "me"
+            })
+
+        self.assertIn("LicenseApiv1providerusers", parent_id_capture.as_object()["Ref"])
+
+        # ensure the handler is created
+        api_stack_template.has_resource_properties(
+            type=CfnFunction.CFN_RESOURCE_TYPE_NAME,
+            props={
+                "Handler": "handlers.provider_users.get_provider_user_me"
+            })
+

--- a/backend/compact-connect/tests/unit/test_app.py
+++ b/backend/compact-connect/tests/unit/test_app.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from aws_cdk import Stack
 from aws_cdk.assertions import Annotations, Match, Template
 from aws_cdk.aws_apigateway import CfnMethod
-from aws_cdk.aws_cognito import CfnUserPoolClient
+from aws_cdk.aws_cognito import CfnUserPoolClient, CfnUserPool
 
 from app import CompactConnectApp
 from stacks.api_stack import ApiStack
@@ -14,6 +14,28 @@ from stacks.persistent_stack import PersistentStack
 
 
 class TestApp(TestCase):
+
+    def _when_testing_production_stack_synth(self):
+        with open('cdk.json', 'r') as f:
+            context = json.load(f)['context']
+        with open('cdk.context.production-example.json', 'r') as f:
+            context['ssm_context'] = json.load(f)['ssm_context']
+
+        # Suppresses lambda bundling for tests
+        context['aws:cdk:bundling-stacks'] = []
+
+        return context
+
+    def _when_testing_sandbox_stack_synth(self):
+        with open('cdk.json', 'r') as f:
+            context = json.load(f)['context']
+        with open('cdk.context.sandbox-example.json', 'r') as f:
+            context.update(json.load(f))
+
+        # Suppresses lambda bundling for tests
+        context['aws:cdk:bundling-stacks'] = []
+
+        return context
 
     def test_no_compact_jurisdiction_name_clash(self):
         """
@@ -42,13 +64,7 @@ class TestApp(TestCase):
         """
         Test infrastructure as deployed via the pipeline
         """
-        with open('cdk.json', 'r') as f:
-            context = json.load(f)['context']
-        with open('cdk.context.production-example.json', 'r') as f:
-            context['ssm_context'] = json.load(f)['ssm_context']
-
-        # Suppresses lambda bundling for tests
-        context['aws:cdk:bundling-stacks'] = []
+        context = self._when_testing_production_stack_synth()
 
         app = CompactConnectApp(context=context)
 
@@ -86,13 +102,7 @@ class TestApp(TestCase):
         """
         Test infrastructure as deployed in a developer's sandbox
         """
-        with open('cdk.json', 'r') as f:
-            context = json.load(f)['context']
-        with open('cdk.context.sandbox-example.json', 'r') as f:
-            context.update(json.load(f))
-
-        # Suppresses lambda bundling for tests
-        context['aws:cdk:bundling-stacks'] = []
+        context = self._when_testing_sandbox_stack_synth()
 
         app = CompactConnectApp(context=context)
 
@@ -115,15 +125,9 @@ class TestApp(TestCase):
         In the case where they opt _not_ to set up a hosted zone and domain name for their sandbox,
         we will skip setting up domain names and DNS records for the API and UI.
         """
-        with open('cdk.json', 'r') as f:
-            context = json.load(f)['context']
-        with open('cdk.context.sandbox-example.json', 'r') as f:
-            context.update(json.load(f))
+        context = self._when_testing_sandbox_stack_synth()
         # Drop domain name to ensure we still handle the optional DNS setup
         del context['ssm_context']['environments'][context['environment_name']]['domain_name']
-
-        # Suppresses lambda bundling for tests
-        context['aws:cdk:bundling-stacks'] = []
 
         app = CompactConnectApp(context=context)
 
@@ -144,15 +148,10 @@ class TestApp(TestCase):
         If a developer tries to deploy this app without either a domain name or allowing a local UI, the app
         should fail to synthesize.
         """
-        with open('cdk.json', 'r') as f:
-            context = json.load(f)['context']
-        with open('cdk.context.sandbox-example.json', 'r') as f:
-            context.update(json.load(f))
+        context = self._when_testing_sandbox_stack_synth()
+
         del context['ssm_context']['environments'][context['environment_name']]['domain_name']
         del context['ssm_context']['environments'][context['environment_name']]['allow_local_ui']
-
-        # Suppresses lambda bundling for tests
-        context['aws:cdk:bundling-stacks'] = []
 
         with self.assertRaises(ValueError):
             CompactConnectApp(context=context)
@@ -161,16 +160,10 @@ class TestApp(TestCase):
         """
         Test infrastructure as deployed in a developer's sandbox
         """
-        with open('cdk.json', 'r') as f:
-            context = json.load(f)['context']
-        with open('cdk.context.sandbox-example.json', 'r') as f:
-            context.update(json.load(f))
+        context = self._when_testing_sandbox_stack_synth()
 
         del context['ssm_context']['environments'][context['environment_name']]['domain_name']
         context['ssm_context']['environments'][context['environment_name']]['local_ui_port'] = '5432'
-
-        # Suppresses lambda bundling for tests
-        context['aws:cdk:bundling-stacks'] = []
 
         app = CompactConnectApp(context=context)
 
@@ -186,6 +179,33 @@ class TestApp(TestCase):
             local_ui_port='5432'
         )
         self._inspect_api_stack(app.sandbox_stage.api_stack)
+
+    def test_synth_generates_provider_user_pool_with_expected_custom_attributes(self):
+        """
+        Test infrastructure as deployed in a developer's sandbox
+        """
+        context = self._when_testing_sandbox_stack_synth()
+
+        app = CompactConnectApp(context=context)
+        persistent_stack_template = Template.from_stack(app.sandbox_stage.persistent_stack)
+
+        # Ensure our Staff user pool is created
+        persistent_stack_template.has_resource_properties(
+            type=CfnUserPool.CFN_RESOURCE_TYPE_NAME,
+            props={
+                "Schema": Match.array_with([
+                    {
+                        "Name": "providerId",
+                        "AttributeDataType": "String",
+                        "Mutable": False
+                    },
+                    {
+                        "Name": "compact",
+                        "AttributeDataType": "String",
+                        "Mutable": False
+                    }
+                ]
+        )})
 
     def _inspect_persistent_stack(
             self,
@@ -205,15 +225,39 @@ class TestApp(TestCase):
             local_ui_port = '3018' if not local_ui_port else local_ui_port
             callbacks.append(f'http://localhost:{local_ui_port}/auth/callback')
 
-        # Ensure our Staff user pool is configured with the expected callbacks
+        # ensure we have two user pools, one for staff users and one for providers
+        persistent_stack_template.resource_count_is(CfnUserPool.CFN_RESOURCE_TYPE_NAME, 2)
+
+        # Ensure our Staff user pool is configured with the expected callbacks and read/write attributes
         persistent_stack_template.has_resource(
             type=CfnUserPoolClient.CFN_RESOURCE_TYPE_NAME,
             props={
                 'Properties': {
-                    'CallbackURLs': callbacks
+                    'CallbackURLs': callbacks,
+                    "ReadAttributes": ["email"],
+                    "WriteAttributes": ["email"],
                 }
             }
         )
+
+        # Ensure our Provider user pool is created with expected values
+        persistent_stack_template.has_resource_properties(
+            type=CfnUserPoolClient.CFN_RESOURCE_TYPE_NAME,
+            props={
+                "ReadAttributes": Match.array_equals([
+                    "custom:compact",
+                    "custom:providerId",
+                    "email",
+                    "family_name",
+                    "given_name"
+                ]),
+                "WriteAttributes": Match.array_equals([
+                    "email",
+                    "family_name",
+                    "given_name"
+                ]),
+                "CallbackURLs": callbacks
+            })
 
     def _inspect_api_stack(self, api_stack: ApiStack):
         api_template = Template.from_stack(api_stack)

--- a/backend/compact-connect/tests/unit/test_app.py
+++ b/backend/compact-connect/tests/unit/test_app.py
@@ -189,7 +189,7 @@ class TestApp(TestCase):
         app = CompactConnectApp(context=context)
         persistent_stack_template = Template.from_stack(app.sandbox_stage.persistent_stack)
 
-        # Ensure our Staff user pool is created
+        # Ensure our provider user pool is created
         persistent_stack_template.has_resource_properties(
             type=CfnUserPool.CFN_RESOURCE_TYPE_NAME,
             props={


### PR DESCRIPTION
This adds a new endpoint to allow provider users that have logged in to see their applicant dashboard.
When a provider user is created, the process that created them will be responsible for setting their provider id 
and their compact as custom attributes on their cognito user identity. These custom attributes will be used to
query the database for their personal information.

### Requirements List
- No new requirements needed to deploy this change.

### Description List
- Added handler to get provider's compact and provider id from their cognito user claims and query for their information.
- Added cdk setup to attach the lambda to the api gateway to process requests.

### Testing List
- `yarn test:unit:all` should run without errors or warnings
- `yarn serve` should run without errors or warnings
- `yarn build` should run without errors or warnings
- Code review

Closes # 202
