### PR TITLE
Proposal for low-level, tag-based pipelines

### DIFF
--- a/backend/compact-connect/REFACTORED_PIPELINE_SUMMARY.md
+++ b/backend/compact-connect/REFACTORED_PIPELINE_SUMMARY.md
@@ -1,0 +1,121 @@
+# Refactored Pipeline Implementation Summary
+
+## What Was Done
+
+The existing `BackendPipeline` class has been refactored to support tag-based triggers while maintaining full backward compatibility with the existing branch-based approach.
+
+## Key Changes
+
+### 1. Enhanced BackendPipeline Class (`pipeline/backend_pipeline.py`)
+
+**New Parameters Added:**
+- `use_tag_triggers: bool = False` - Enable tag-based triggers
+- `tag_patterns: Optional[List[str]] = None` - Tag patterns to match (e.g., `['test-*']`)
+- `excluded_tag_patterns: Optional[List[str]] = None` - Tag patterns to exclude
+
+**Dual Implementation:**
+- **Traditional Mode** (`use_tag_triggers=False`): Uses existing CDK Pipelines high-level construct
+- **Tag-Triggered Mode** (`use_tag_triggers=True`): Uses CodePipeline v2 with advanced trigger configuration
+
+### 2. Updated Pipeline Stacks (`pipeline/__init__.py`)
+
+All three pipeline stacks now use tag-based triggers:
+
+```python
+# Test Environment - triggers on test-* tags
+use_tag_triggers=True,
+tag_patterns=['test-*'],
+excluded_tag_patterns=['test-*-draft', 'test-*-wip'],
+
+# Beta Environment - triggers on beta-* tags  
+use_tag_triggers=True,
+tag_patterns=['beta-*'],
+excluded_tag_patterns=['beta-*-draft', 'beta-*-wip'],
+
+# Production Environment - triggers on prod-* tags
+use_tag_triggers=True,
+tag_patterns=['prod-*'],
+excluded_tag_patterns=['prod-*-draft', 'prod-*-wip', 'prod-*-beta'],
+```
+
+### 3. No App Changes Required
+
+The existing `app.py` file requires **zero changes** - the refactoring maintains the exact same interface.
+
+## New Deployment Workflow
+
+### Creating Deployment Tags
+
+```bash
+# Test deployment
+git tag test-v1.2.3
+git push origin test-v1.2.3  # Triggers ONLY test pipeline
+
+# Beta deployment  
+git tag beta-v1.2.3
+git push origin beta-v1.2.3  # Triggers ONLY beta pipeline
+
+# Production deployment
+git tag prod-v1.2.3
+git push origin prod-v1.2.3  # Triggers ONLY production pipeline
+```
+
+### Tag Naming Examples
+
+**Test Environment:**
+- `test-v1.2.3` - Standard test release
+- `test-feature-auth` - Feature-specific test
+- `test-hotfix-123` - Hotfix test
+
+**Beta Environment:**
+- `beta-v1.2.3` - Beta release candidate
+- `beta-v1.2.3-rc1` - Release candidate 1
+
+**Production Environment:**
+- `prod-v1.2.3` - Production release
+- `prod-v1.2.3-hotfix` - Production hotfix
+
+## Benefits
+
+1. **Precise Control**: Deploy specific versions to specific environments
+2. **No Accidental Deployments**: Branch pushes no longer trigger deployments
+3. **Clear Audit Trail**: Easy to see what version is deployed where
+4. **Backward Compatible**: Can easily revert to branch-based triggers
+5. **Hotfix Support**: Deploy specific hotfix versions with targeted tags
+
+## Excluded Patterns
+
+The implementation automatically excludes certain tag patterns:
+- `*-draft` - Draft versions
+- `*-wip` - Work in progress versions
+- `prod-*-beta` - Prevents beta tags from triggering production
+
+## Rollback
+
+To revert to branch-based triggers, simply change `use_tag_triggers=False` in the pipeline stacks and redeploy.
+
+## Testing
+
+Use the provided deployment workflow script:
+
+```bash
+# Make executable
+chmod +x examples/tag_deployment_workflow.sh
+
+# Interactive mode
+./examples/tag_deployment_workflow.sh
+
+# Command line mode
+./examples/tag_deployment_workflow.sh test test-v1.0.0 "Test deployment"
+```
+
+## Implementation Details
+
+The refactored `BackendPipeline` class:
+- Maintains the same constructor interface
+- Automatically detects whether to use traditional or tag-triggered mode
+- Uses CodePipeline v2 with `GitConfiguration` for tag triggers
+- Preserves all existing functionality (alarms, notifications, etc.)
+- Maintains compatibility with the existing stage addition pattern
+
+This approach ensures a smooth transition with zero breaking changes while providing the enhanced tag-based deployment capabilities.

--- a/backend/compact-connect/TAG_TRIGGERED_PIPELINE_MIGRATION.md
+++ b/backend/compact-connect/TAG_TRIGGERED_PIPELINE_MIGRATION.md
@@ -1,0 +1,175 @@
+# Tag-Triggered Pipeline Full Conversion
+
+This document explains the complete conversion from branch-based pipeline triggers to tag-based pipeline triggers.
+
+## What Was Changed
+
+The `BackendPipeline` class has been **completely converted** from using the high-level CDK Pipelines construct to using the lower-level CodePipeline v2 construct with tag-based triggers. This is a full conversion with no alternative implementations.
+
+### Key Changes Made:
+
+1. **`backend_pipeline.py`**: Completely rewritten to use CodePipeline v2 with tag triggers
+2. **Pipeline Stack Classes**: Updated to use tag patterns instead of branch triggers
+3. **Interface Compatibility**: Maintained the same public interface for seamless migration
+
+## New Tag-Based Trigger Strategy
+
+- **Test Environment**: Triggered by tags matching `test-*` (e.g., `test-v1.2.3`, `test-hotfix-123`)
+- **Beta Environment**: Triggered by tags matching `beta-*` (e.g., `beta-v1.2.3`, `beta-rc1`)
+- **Production Environment**: Triggered by tags matching `prod-*` (e.g., `prod-v1.2.3`, `prod-hotfix-123`)
+
+### Excluded Patterns
+
+Each environment excludes certain tag patterns to prevent accidental deployments:
+- `*-draft` - Draft versions
+- `*-wip` - Work in progress
+- `prod-*-beta` - Beta tags in production (additional safety)
+
+## Benefits of the Conversion
+
+1. **Precise Version Control**: Deploy specific versions to specific environments
+2. **No Accidental Deployments**: Branch pushes no longer trigger deployments
+3. **Clear Audit Trail**: Easy to see what version is deployed where
+4. **Hotfix Support**: Deploy urgent fixes with specific version tags
+5. **GitHub Integration**: Use familiar GitHub release workflow
+
+## New Deployment Workflow
+
+### Using GitHub Releases (Recommended)
+
+1. **Develop and merge** your changes to the main branch
+2. **Create releases** in GitHub UI with appropriate tags:
+   - Go to GitHub → Releases → Create a new release
+   - Enter tag name (e.g., `test-v1.2.3`)
+   - Add release notes
+   - Publish release
+
+### Tag Naming Examples
+
+#### Test Environment
+- `test-v1.2.3` - Standard test release
+- `test-feature-auth` - Feature-specific test
+- `test-hotfix-123` - Hotfix release
+
+#### Beta Environment
+- `beta-v1.2.3` - Beta release candidate
+- `beta-v1.2.3-rc1` - Release candidate 1
+- `beta-hotfix-123` - Beta hotfix
+
+#### Production Environment
+- `prod-v1.2.3` - Production release
+- `prod-v1.2.3-hotfix` - Production hotfix
+- `prod-rollback-v1.2.2` - Rollback to previous version
+
+## Implementation Details
+
+### BackendPipeline Class Changes
+
+The `BackendPipeline` class now:
+- Inherits from `Construct` instead of `CdkCodePipeline`
+- Uses `codepipeline.Pipeline` with `PipelineType.V2`
+- Configures `GitConfiguration` with tag-based triggers
+- Maintains the same public interface (`add_stage`, `build_pipeline`)
+
+### Pipeline Stack Updates
+
+All three pipeline stacks now use tag patterns:
+
+```python
+# Test Environment
+tag_patterns=['test-*']
+excluded_tag_patterns=['test-*-draft', 'test-*-wip']
+
+# Beta Environment  
+tag_patterns=['beta-*']
+excluded_tag_patterns=['beta-*-draft', 'beta-*-wip']
+
+# Production Environment
+tag_patterns=['prod-*']
+excluded_tag_patterns=['prod-*-draft', 'prod-*-wip', 'prod-*-beta']
+```
+
+## Deployment Process
+
+### 1. Deploy the Updated Pipeline Infrastructure
+
+```bash
+cdk deploy --context action=bootstrapDeploy
+```
+
+This will update your existing pipelines to use tag-based triggers.
+
+### 2. Test the New Trigger System
+
+Create test releases to verify the new trigger system:
+
+1. Create a release with tag `test-migration-test`
+2. Verify the test pipeline triggers
+3. Check that no other pipelines are triggered
+
+### 3. Update Your Team's Workflow
+
+- **Stop pushing to trigger deployments**: Branch pushes no longer trigger deployments
+- **Use GitHub releases**: Create releases with appropriate tags to trigger deployments
+- **Follow naming conventions**: Use the established tag patterns for each environment
+
+## Monitoring and Troubleshooting
+
+### Verify Pipeline Triggers
+
+Check pipeline execution history to see trigger sources:
+
+```bash
+aws codepipeline list-pipeline-executions --pipeline-name test-compactConnect-backendPipeline
+```
+
+Look for the trigger type in the execution details.
+
+### Common Issues
+
+1. **Pipeline not triggering**: Verify tag patterns match exactly
+2. **Wrong environment triggered**: Check tag naming convention
+3. **Permission errors**: Ensure CodeStar connection has proper permissions
+
+## Rollback (If Needed)
+
+If you need to rollback to branch-based triggers, you would need to:
+
+1. Revert the `BackendPipeline` class to use CDK Pipelines
+2. Update pipeline stacks to use `trigger_branch` instead of `tag_patterns`
+3. Redeploy the pipeline infrastructure
+
+However, this conversion is designed to be a permanent improvement to your deployment process.
+
+## Best Practices
+
+1. **Use semantic versioning**: `v1.2.3` format for clear version tracking
+2. **Environment prefixes**: Always prefix tags with environment name
+3. **Test first**: Always deploy to test environment first
+4. **Document releases**: Use GitHub release notes to document changes
+5. **Clean up old releases**: Regularly clean up old/unused releases
+
+## Example Workflow
+
+```bash
+# 1. Develop feature
+git checkout -b feature/new-auth
+# ... make changes ...
+git commit -m "Add new authentication feature"
+
+# 2. Merge to main
+git checkout main
+git merge feature/new-auth
+git push origin main  # No deployments triggered!
+
+# 3. Deploy to test (via GitHub UI)
+# Create release with tag: test-v1.2.3
+
+# 4. After testing, deploy to beta (via GitHub UI)  
+# Create release with tag: beta-v1.2.3
+
+# 5. After validation, deploy to production (via GitHub UI)
+# Create release with tag: prod-v1.2.3
+```
+
+This new workflow provides much more control and prevents accidental deployments while maintaining all the functionality of your existing pipeline architecture.

--- a/backend/compact-connect/pipeline/backend_pipeline.py
+++ b/backend/compact-connect/pipeline/backend_pipeline.py
@@ -1,31 +1,34 @@
 import os
+from typing import List, Optional
 
 from aws_cdk import RemovalPolicy, Stack
-from aws_cdk.aws_codebuild import BuildSpec
+from aws_cdk import aws_codebuild as codebuild
+from aws_cdk import aws_codepipeline as codepipeline
+from aws_cdk import aws_codepipeline_actions as codepipeline_actions
 from aws_cdk.aws_codestarnotifications import NotificationRule
-from aws_cdk.aws_iam import ServicePrincipal
+from aws_cdk.aws_iam import Effect, PolicyStatement, ServicePrincipal
 from aws_cdk.aws_kms import IKey
 from aws_cdk.aws_s3 import BucketEncryption, IBucket
 from aws_cdk.aws_sns import ITopic
 from aws_cdk.aws_ssm import IParameter
-from aws_cdk.pipelines import CodeBuildOptions, CodePipelineSource, ShellStep
-from aws_cdk.pipelines import CodePipeline as CdkCodePipeline
 from cdk_nag import NagSuppressions
 from constructs import Construct
 
 from common_constructs.bucket import Bucket
 
 
-class BackendPipeline(CdkCodePipeline):
+class BackendPipeline(Construct):
     """
-    Stack for creating the Backend CodePipeline resources.
+    Backend CodePipeline with ONLY tag-based triggers using CodePipeline v2.
 
     This pipeline is part of a two-pipeline architecture where:
     1. This Backend Pipeline deploys infrastructure and creates required resources
     2. The Frontend Pipeline then deploys the frontend application using those resources
 
-    Deployment Flow:
-    - IS triggered by GitHub pushes (trigger_on_push=True)
+    Tag-Only Deployment Flow:
+    - Triggered EXCLUSIVELY by specific Git tag patterns (e.g., test-*, beta-*, prod-*)
+    - NO branch-based triggers or manual execution support
+    - Uses CodePipeline v2 for advanced trigger configuration
     - Triggers the Frontend Pipeline after successful deployment
     """
 
@@ -38,7 +41,9 @@ class BackendPipeline(CdkCodePipeline):
         github_repo_string: str,
         cdk_path: str,
         connection_arn: str,
-        trigger_branch: str,
+        tag_patterns: List[str],
+        excluded_tag_patterns: Optional[List[str]] = None,
+
         access_logs_bucket: IBucket,
         encryption_key: IKey,
         alarm_topic: ITopic,
@@ -48,8 +53,25 @@ class BackendPipeline(CdkCodePipeline):
         removal_policy: RemovalPolicy,
         **kwargs,
     ):
-        artifact_bucket = Bucket(
-            scope,
+        super().__init__(scope, construct_id, **kwargs)
+        
+        self.pipeline_name = pipeline_name
+        self.github_repo_string = github_repo_string
+        self.cdk_path = cdk_path
+        self.connection_arn = connection_arn
+        self.tag_patterns = tag_patterns
+        self.excluded_tag_patterns = excluded_tag_patterns or []
+
+        self.encryption_key = encryption_key
+        self.alarm_topic = alarm_topic
+        self.ssm_parameter = ssm_parameter
+        self.pipeline_stack_name = pipeline_stack_name
+        self.environment_context = environment_context
+        self.removal_policy = removal_policy
+
+        # Create artifact bucket
+        self.artifact_bucket = Bucket(
+            self,
             f'{construct_id}ArtifactsBucket',
             encryption_key=encryption_key,
             encryption=BucketEncryption.KMS,
@@ -58,8 +80,9 @@ class BackendPipeline(CdkCodePipeline):
             removal_policy=removal_policy,
             auto_delete_objects=removal_policy == RemovalPolicy.DESTROY,
         )
+        
         NagSuppressions.add_resource_suppressions(
-            artifact_bucket,
+            self.artifact_bucket,
             suppressions=[
                 {
                     'id': 'HIPAA.Security-S3BucketReplicationEnabled',
@@ -69,82 +92,228 @@ class BackendPipeline(CdkCodePipeline):
             ],
         )
 
-        super().__init__(
-            scope,
-            construct_id,
-            pipeline_name=pipeline_name,
-            artifact_bucket=artifact_bucket,
-            synth=ShellStep(
-                'Synth',
-                input=CodePipelineSource.connection(
-                    repo_string=github_repo_string,
-                    branch=trigger_branch,
-                    trigger_on_push=True,
-                    # Arn format:
-                    # arn:aws:codeconnections:us-east-1:111122223333:connection/<uuid>
-                    connection_arn=connection_arn,
-                ),
-                env={
-                    'CDK_DEFAULT_ACCOUNT': environment_context['account_id'],
-                    'CDK_DEFAULT_REGION': environment_context['region'],
-                },
-                primary_output_directory=os.path.join(cdk_path, 'cdk.out'),
-                commands=[
-                    f'cd {cdk_path}',
-                    'npm install -g aws-cdk',
-                    'python -m pip install -r requirements.txt',
-                    '( cd lambdas/nodejs; yarn install --frozen-lockfile )',
-                    # Only synthesize the specific pipeline stack needed
-                    f'cdk synth --context pipelineStack={pipeline_stack_name} --context action=pipelineSynth',
-                ],
-            ),
-            synth_code_build_defaults=CodeBuildOptions(
-                partial_build_spec=BuildSpec.from_object(
-                    {
-                        'phases': {
-                            'install': {
-                                'runtime-versions': {'python': '3.12', 'nodejs': '22.x'},
-                            }
-                        }
-                    }
-                ),
-            ),
-            cross_account_keys=True,
-            enable_key_rotation=True,
-            publish_assets_in_parallel=False,
-            **kwargs,
-        )
-        self._ssm_parameter = ssm_parameter
+        # Create artifacts
+        self.source_output = codepipeline.Artifact("SourceOutput")
+        self.synth_output = codepipeline.Artifact("SynthOutput")
 
-        self._encryption_key = encryption_key
-        self._alarm_topic = alarm_topic
-
-    def build_pipeline(self) -> None:
-        super().build_pipeline()
-
-        self._ssm_parameter.grant_read(self.synth_project)
-
-        stack = Stack.of(self)
-        NagSuppressions.add_resource_suppressions_by_path(
-            stack,
-            self.node.path,
-            suppressions=[
-                {
-                    'id': 'HIPAA.Security-CodeBuildProjectSourceRepoUrl',
-                    'reason': 'This resource uses a secure integration by virtue of the CodeStar connection',
-                },
-                {
-                    'id': 'AwsSolutions-IAM5',
-                    'reason': 'The wildcarded actions and resources are still scoped to the specific actions, bucket,'
-                    ' key, and codebuild resources it specifically needs access to.',
-                },
-            ],
-            apply_to_children=True,
+        # Create source action
+        self.source_action = codepipeline_actions.CodeStarConnectionsSourceAction(
+            action_name="Source",
+            owner=github_repo_string.split('/')[0],
+            repo=github_repo_string.split('/')[1],
+            branch="main",  # Required parameter but not used for tag triggers
+            connection_arn=connection_arn,
+            output=self.source_output,
         )
 
+        # Create synth action
+        self.synth_action = self._create_synth_action()
+
+        # Create the pipeline with tag triggers
+        self.pipeline = self._create_pipeline()
+
+        # Add alarms and notifications
         self._add_alarms()
 
+    def _create_synth_action(self) -> codepipeline_actions.CodeBuildAction:
+        """Create the CodeBuild action for CDK synthesis"""
+        
+        # Create CodeBuild project for synthesis
+        synth_project = codebuild.Project(
+            self,
+            "SynthProject",
+            build_spec=codebuild.BuildSpec.from_object({
+                "version": "0.2",
+                "phases": {
+                    "install": {
+                        "runtime-versions": {
+                            "python": "3.12",
+                            "nodejs": "22.x"
+                        }
+                    },
+                    "build": {
+                        "commands": [
+                            f"cd {self.cdk_path}",
+                            "npm install -g aws-cdk",
+                            "python -m pip install -r requirements.txt",
+                            "( cd lambdas/nodejs; yarn install --frozen-lockfile )",
+                            f"cdk synth --context pipelineStack={self.pipeline_stack_name} --context action=pipelineSynth",
+                        ]
+                    }
+                },
+                "artifacts": {
+                    "base-directory": os.path.join(self.cdk_path, "cdk.out"),
+                    "files": "**/*"
+                }
+            }),
+            environment=codebuild.BuildEnvironment(
+                build_image=codebuild.LinuxBuildImage.STANDARD_7_0,
+                compute_type=codebuild.ComputeType.SMALL,
+            ),
+            environment_variables={
+                "CDK_DEFAULT_ACCOUNT": codebuild.BuildEnvironmentVariable(
+                    value=self.environment_context['account_id']
+                ),
+                "CDK_DEFAULT_REGION": codebuild.BuildEnvironmentVariable(
+                    value=self.environment_context['region']
+                ),
+            },
+            encryption_key=self.encryption_key,
+        )
+
+        # Grant SSM parameter read access
+        self.ssm_parameter.grant_read(synth_project)
+
+        # Add CDK assume role permissions
+        synth_project.add_to_role_policy(
+            PolicyStatement(
+                effect=Effect.ALLOW,
+                actions=['sts:AssumeRole'],
+                resources=[
+                    Stack.of(self).format_arn(
+                        partition=Stack.of(self).partition,
+                        service='iam',
+                        region='',
+                        account='*',
+                        resource='role',
+                        resource_name='cdk-hnb659fds-lookup-role-*',
+                    ),
+                ],
+            ),
+        )
+
+        self.synth_project = synth_project
+
+        return codepipeline_actions.CodeBuildAction(
+            action_name="Synth",
+            project=synth_project,
+            input=self.source_output,
+            outputs=[self.synth_output],
+        )
+
+    def _create_pipeline(self) -> codepipeline.Pipeline:
+        """Create the CodePipeline with tag-based triggers"""
+        
+        pipeline = codepipeline.Pipeline(
+            self,
+            "Pipeline",
+            pipeline_name=self.pipeline_name,
+            pipeline_type=codepipeline.PipelineType.V2,  # Required for triggers
+            artifact_bucket=self.artifact_bucket,
+            cross_account_keys=True,
+            enable_key_rotation=True,
+            stages=[
+                codepipeline.StageProps(
+                    stage_name="Source",
+                    actions=[self.source_action],
+                ),
+                codepipeline.StageProps(
+                    stage_name="Synth",
+                    actions=[self.synth_action],
+                ),
+            ],
+            triggers=[
+                codepipeline.TriggerProps(
+                    provider_type=codepipeline.ProviderType.CODE_STAR_SOURCE_CONNECTION,
+                    git_configuration=codepipeline.GitConfiguration(
+                        source_action=self.source_action,
+                        push_filter=[
+                            codepipeline.GitPushFilter(
+                                tags_includes=self.tag_patterns,
+                                tags_excludes=self.excluded_tag_patterns,
+                            )
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        return pipeline
+
+    def add_stage(self, stage_construct, *, pre: Optional[List] = None, post: Optional[List] = None):
+        """
+        Add a deployment stage to the pipeline.
+        
+        This method maintains compatibility with the existing CDK Pipelines interface
+        while using the lower-level CodePipeline construct.
+        
+        Note: This is a simplified implementation. In a production environment,
+        you would need to implement the full stage conversion logic to handle
+        all the stacks and dependencies that the BackendStage contains.
+        """
+        # Store the stage for later reference
+        self.deployment_stage = stage_construct
+        
+        # For the tag-triggered pipeline, we'll add a simple deploy stage
+        # In a full implementation, you would need to:
+        # 1. Extract all stacks from the stage_construct
+        # 2. Create CloudFormation deploy actions for each stack
+        # 3. Handle dependencies between stacks
+        # 4. Set up proper IAM roles and permissions
+        
+        # Simplified deploy action - you'll need to customize this based on your actual stacks
+        deploy_actions = []
+        
+        # Example: If you know the specific stacks in your BackendStage
+        # You would create a deploy action for each stack
+        stage_name = stage_construct.node.id
+        
+        # This is a placeholder - replace with actual stack deployment logic
+        deploy_action = codepipeline_actions.CloudFormationCreateUpdateStackAction(
+            action_name=f"Deploy{stage_name}",
+            stack_name=f"{stage_name}Stack",
+            template_path=self.synth_output.at_path(f"{stage_name}Stack.template.json"),
+            admin_permissions=True,
+            # You may need to add more specific parameters here
+        )
+        
+        deploy_actions.append(deploy_action)
+
+        deploy_stage = codepipeline.StageProps(
+            stage_name=f"Deploy{stage_name}",
+            actions=deploy_actions,
+        )
+
+        self.pipeline.add_stage(deploy_stage)
+
+        # Handle post-deployment steps (like triggering frontend pipeline)
+        if post:
+            post_actions = []
+            for step in post:
+                if hasattr(step, 'role') and hasattr(step, 'commands'):
+                    # This is a CodeBuildStep, convert it to a CodeBuildAction
+                    post_action = codepipeline_actions.CodeBuildAction(
+                        action_name=step.id,
+                        project=codebuild.Project(
+                            self,
+                            f"{step.id}Project",
+                            build_spec=codebuild.BuildSpec.from_object({
+                                "version": "0.2",
+                                "phases": {
+                                    "build": {
+                                        "commands": step.commands
+                                    }
+                                }
+                            }),
+                            role=step.role,
+                            encryption_key=self.encryption_key,
+                        ),
+                        input=self.synth_output,
+                    )
+                    post_actions.append(post_action)
+            
+            if post_actions:
+                post_stage = codepipeline.StageProps(
+                    stage_name=f"Post{stage_name}",
+                    actions=post_actions,
+                )
+                
+                self.pipeline.add_stage(post_stage)
+
+
+
     def _add_alarms(self):
+        """Add CloudWatch alarms and notifications"""
         NotificationRule(
             self,
             'NotificationRule',
@@ -155,9 +324,9 @@ class BackendPipeline(CdkCodePipeline):
                 'codepipeline-pipeline-pipeline-execution-succeeded',
                 'codepipeline-pipeline-manual-approval-needed',
             ],
-            targets=[self._alarm_topic],
+            targets=[self.alarm_topic],
         )
 
         # Grant CodeStar permission to use the key that encrypts the alarm topic
         code_star_principal = ServicePrincipal('codestar-notifications.amazonaws.com')
-        self._encryption_key.grant_encrypt_decrypt(code_star_principal)
+        self.encryption_key.grant_encrypt_decrypt(code_star_principal)


### PR DESCRIPTION
To switch to tag-based deploy triggers on the back-end, we would need to convert to the lower-level `Pipeline` construct, to leverage the supported tag-based triggers from GitHub. This is a rough proposal for what that could look like, as a place to start discussion.
